### PR TITLE
Fix the warning and error:

### DIFF
--- a/pywedge.py
+++ b/pywedge.py
@@ -24,10 +24,11 @@ class Pywedge_Charts():
         self.train = train
         self.c = c
         self.y = y
-        self.X = self.train.drop(self.y,1)
+        self.X = self.train.drop(columns=self.y)
         self.manual = manual
 
     def make_charts(self):
+	from IPython.display import display
         import pandas as pd
         import ipywidgets as widgets
         import plotly.express as px


### PR DESCRIPTION
FutureWarning: In a future version of pandas all arguments of DataFrame.drop except for the argument 'labels' will be keyword-only

Fix the error:
NameError: name 'display' is not defined

Below were the complete Warning and Error:

```
FutureWarning: In a future version of pandas all arguments of DataFrame.drop except for the argument 'labels' will be keyword-only
  self.X = self.train.drop(self.y,1)
Traceback (most recent call last):
  File "tuba.py", line 14, in <module>
    chart = mc.make_charts()
  File "/home/sahil/pywedge/pywedge.py", line 42, in make_charts
    display(header)
NameError: name 'display' is not defined
```